### PR TITLE
perf: Remove nested loop

### DIFF
--- a/contracts/Raffle.sol
+++ b/contracts/Raffle.sol
@@ -395,6 +395,24 @@ contract Raffle is
 
         uint256[] memory winningEntriesBitmap = new uint256[]((currentEntryIndex >> 8) + 1);
 
+        uint256[] memory currentEntryIndexArray = new uint256[](entriesCount);
+        for (uint256 i; i < entriesCount; ) {
+            currentEntryIndexArray[i] = entries[i].currentEntryIndex;
+            unchecked {
+                ++i;
+            }
+        }
+
+        Prize[] storage prizes = raffle.prizes;
+        uint256 prizesCount = prizes.length;
+        uint256[] memory cumulativeWinnersCountArray = new uint256[](prizesCount);
+        for (uint256 i; i < prizesCount; ) {
+            cumulativeWinnersCountArray[i] = prizes[i].cumulativeWinnersCount;
+            unchecked {
+                ++i;
+            }
+        }
+
         for (uint256 i; i < winnersCount; ) {
             uint256 winningEntry = randomWords[i] % (currentEntryIndex + 1);
             (winningEntry, winningEntriesBitmap) = _incrementWinningEntryUntilThereIsNotADuplicate(
@@ -403,23 +421,6 @@ contract Raffle is
                 winningEntriesBitmap
             );
 
-            uint256[] memory currentEntryIndexArray = new uint256[](entriesCount);
-            for (uint256 j; j < entriesCount; ) {
-                currentEntryIndexArray[j] = entries[j].currentEntryIndex;
-                unchecked {
-                    ++j;
-                }
-            }
-
-            Prize[] storage prizes = raffle.prizes;
-            uint256 prizesCount = prizes.length;
-            uint256[] memory cumulativeWinnersCountArray = new uint256[](prizesCount);
-            for (uint256 j; j < prizesCount; ) {
-                cumulativeWinnersCountArray[j] = prizes[j].cumulativeWinnersCount;
-                unchecked {
-                    ++j;
-                }
-            }
             winners[i].participant = entries[currentEntryIndexArray.findUpperBound(winningEntry)].participant;
             winners[i].entryIndex = uint40(winningEntry);
             winners[i].prizeIndex = uint8(cumulativeWinnersCountArray.findUpperBound(i + 1));


### PR DESCRIPTION
```
test_claimPrizes_MultipleRaffles() (gas: -87696 (-2.812%))
test_claimPrizes_StatusIsComplete() (gas: -237753 (-2.900%))
test_claimPrizes_RevertIf_PrizeAlreadyClaimed() (gas: -237753 (-2.916%))
test_claimPrizes_StatusIsDrawn() (gas: -237753 (-2.917%))
test_claimPrizes_RevertIf_InvalidCaller() (gas: -237753 (-3.090%))
test_claimFees() (gas: -237753 (-3.099%))
test_selectWinners_SomeParticipantsDrawnMoreThanOnce_MultipleBucketsWithOverflow() (gas: -1058311 (-3.102%))
test_claimFees_ContractOwnerCanAlsoCallTheFunction() (gas: -237753 (-3.103%))
test_selectWinners_SomeParticipantsDrawnMoreThanOnce() (gas: -237753 (-3.110%))
test_selectWinners() (gas: -237753 (-3.114%))
test_claimPrizes_RevertIf_InvalidIndex() (gas: -237753 (-3.115%))
test_claimFees_RevertIf_InvalidCaller() (gas: -237753 (-3.121%))
test_selectWinners_RevertIf_InvalidStatus() (gas: -237753 (-3.121%))
testFuzz_selectWinners(uint248) (gas: -49322 (-3.352%))
test_claimPrizes_MultiplePrizes() (gas: -43848 (-3.662%))
Overall gas change: -3854460 (-1.571%)
```